### PR TITLE
List cited sources after the response

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -232,10 +232,19 @@ class PerplexityServer {
           messages: [{ role: "user", content: prompt }],
         });
 
+        // response.data can have a string[] .citations
+        // these are referred to in the return text as numbered citations e.g. [1]
+        const sourcesText = response.data.citations
+          ? `\n## Sources\nPlease keep the numbered citations inline.\n
+          ${response.data.citations
+            .map((c: string, i: number) => `${i + 1}: ${c}`)
+            .join("\n")}`
+          : "";
+
         return {
           content: [{
             type: "text",
-            text: response.data.choices[0].message.content
+            text: response.data.choices[0].message.content + sourcesText,
           }]
         };
       } catch (error) {


### PR DESCRIPTION
The perplexity API returns a list of string citations, as a separate attribute, that it refers to in the text as e.g. `[1]`

This patch handles that `response.data.citations` and adds it to the response. In my experiments with this MCP server in VSCode, the VSCode LLM lists the sources as well.

See the screenshot for an example:

<img width="867" alt="image" src="https://github.com/user-attachments/assets/8bc43cc4-a4e7-44c3-ae3b-ada7472e1c41" />
